### PR TITLE
Add the option to disable the double click action and a few other changes to the settings.

### DIFF
--- a/launcher/src/main/java/com/benny/openlauncher/activity/SettingsActivity.java
+++ b/launcher/src/main/java/com/benny/openlauncher/activity/SettingsActivity.java
@@ -1,21 +1,17 @@
 package com.benny.openlauncher.activity;
 
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Environment;
-import android.support.annotation.NonNull;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
-import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.benny.openlauncher.hideApps.Activity_hideApps;
 import com.benny.openlauncher.util.AppManager;
@@ -53,35 +49,37 @@ public class SettingsActivity extends BaseSettingsActivity implements MaterialPr
 
                     .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_desktop)))
                     .add(new MaterialPrefFragment.ButtonPref("desktopMode", (getString(R.string.settings_desktopStyle)), (getString(R.string.settings_desktopStyle_summary))))
-                    .add(new MaterialPrefFragment.TBPref("desktopSearchBar", (getString(R.string.settings_desktopSearch)), (getString(R.string.settings_desktopSearch_summary)), generalSettings.desktopSearchBar))
                     // FIXME: 11/25/2016 This will have problem (in allappsmode) as the apps will be cut off when scale down
                     .add(new MaterialPrefFragment.NUMPref("gridSizeDesktop",(getString(R.string.settings_desktopSize)), (getString(R.string.settings_desktopSize_summary)),
                             new MaterialPrefFragment.NUMPref.NUMPrefItem("hGridSizeDesktop",(getString(R.string.settings_column)), generalSettings.desktopGridX, 4, 10),
                             new MaterialPrefFragment.NUMPref.NUMPrefItem("vGridSizeDesktop",(getString(R.string.settings_row)), generalSettings.desktopGridY, 4, 10)
                     ))
+                    .add(new MaterialPrefFragment.TBPref("desktopSearchBar", (getString(R.string.settings_desktopSearch)), (getString(R.string.settings_desktopSearch_summary)), generalSettings.desktopSearchBar))
                     .add(new MaterialPrefFragment.TBPref("fullscreen", (getString(R.string.settings_desktopFull)), (getString(R.string.settings_desktopFull_summary)), generalSettings.fullscreen))
-                    .add(new MaterialPrefFragment.TBPref("swipe", (getString(R.string.settings_desktopSwipe)), (getString(R.string.settings_desktopSwipe_summary)), generalSettings.swipe))
-                    .add(new MaterialPrefFragment.TBPref("clickToOpen", (getString(R.string.settings_desktopClick)), (getString(R.string.settings_desktopClick_summary)), generalSettings.clickToOpen))
                     .add(new MaterialPrefFragment.TBPref("showIndicator", (getString(R.string.settings_desktopIndicator)), (getString(R.string.settings_desktopIndicator_summary)), generalSettings.showIndicator))
 
 
                     .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_dock)))
-                    .add(new MaterialPrefFragment.TBPref("dockShowLabel",(getString(R.string.settings_dockLabel)),(getString(R.string.settings_dockLabel_summary)), generalSettings.dockShowLabel))
                     .add(new MaterialPrefFragment.NUMPref("gridSizeDock",(getString(R.string.settings_dockSize)), (getString(R.string.settings_dockSize_summary)),
                             new MaterialPrefFragment.NUMPref.NUMPrefItem("hGridSizeDock",(getString(R.string.settings_column)), generalSettings.dockGridX, 5, 10)
                     ))
+                    .add(new MaterialPrefFragment.TBPref("dockShowLabel",(getString(R.string.settings_dockLabel)),(getString(R.string.settings_dockLabel_summary)), generalSettings.dockShowLabel))
 
 
                     .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_drawer)))
                     .add(new MaterialPrefFragment.ButtonPref("drawerStyle", (getString(R.string.settings_drawerStyle)), (getString(R.string.settings_drawerStyle_summary))))
-                    .add(new MaterialPrefFragment.TBPref("drawerCard", (getString(R.string.settings_drawerCard)), (getString(R.string.settings_drawerCard_summary)), generalSettings.drawerUseCard))
-                    .add(new MaterialPrefFragment.TBPref("drawerSearchBar", (getString(R.string.settings_drawerSearch)), (getString(R.string.settings_drawerSearch_summary)), generalSettings.drawerSearchBar))
                     .add(new MaterialPrefFragment.NUMPref("gridSize",(getString(R.string.settings_drawerSize)), (getString(R.string.settings_drawerSize_summary)),
                             new MaterialPrefFragment.NUMPref.NUMPrefItem("hGridSize",(getString(R.string.settings_column)), generalSettings.drawerGridX, 1, 10),
                             new MaterialPrefFragment.NUMPref.NUMPrefItem("vGridSize",(getString(R.string.settings_row)), generalSettings.drawerGridY, 1, 10)
                     ))
+                    .add(new MaterialPrefFragment.TBPref("drawerCard", (getString(R.string.settings_drawerCard)), (getString(R.string.settings_drawerCard_summary)), generalSettings.drawerUseCard))
+                    .add(new MaterialPrefFragment.TBPref("drawerSearchBar", (getString(R.string.settings_drawerSearch)), (getString(R.string.settings_drawerSearch_summary)), generalSettings.drawerSearchBar))
                     .add(new MaterialPrefFragment.TBPref("drawerRememberPage", (getString(R.string.settings_drawerPage)), (getString(R.string.settings_drawerPage_summary)), !generalSettings.drawerRememberPage))
 
+                    .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_input)))
+                    .add(new MaterialPrefFragment.TBPref("swipe", (getString(R.string.settings_desktopSwipe)), (getString(R.string.settings_desktopSwipe_summary)), generalSettings.swipe))
+                    .add(new MaterialPrefFragment.TBPref("clickToOpen", (getString(R.string.settings_desktopClick)), (getString(R.string.settings_desktopClick_summary)), generalSettings.clickToOpen))
+                    .add(new MaterialPrefFragment.TBPref("doubleClick", (getString(R.string.settings_doubleClick)), (getString(R.string.settings_doubleClick_summary)), generalSettings.doubleClick))
 
                     .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_color)))
                     .add(new MaterialPrefFragment.ColorPref("dockBackground",(getString(R.string.settings_colorDock)),(getString(R.string.settings_colorDock_summary)),generalSettings.dockColor))
@@ -96,7 +94,7 @@ public class SettingsActivity extends BaseSettingsActivity implements MaterialPr
                     .add(new MaterialPrefFragment.ButtonPref("iconHide", (getString(R.string.settings_iconHide)), (getString(R.string.settings_iconHide_summary))))
 
 
-                    .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_others)))
+                    .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_other)))
                     .add(new MaterialPrefFragment.ButtonPref("backup", (getString(R.string.settings_backup)), (getString(R.string.settings_backup_summary))))
                     .add(new MaterialPrefFragment.ButtonPref("restart", getString(R.string.settings_othersRestart), getString(R.string.settings_othersRestart_summary)))
                     .setOnPrefChangedListener(this).setOnPrefClickedListener(this));
@@ -149,6 +147,9 @@ public class SettingsActivity extends BaseSettingsActivity implements MaterialPr
                 break;
             case "clickToOpen":
                 generalSettings.clickToOpen = (boolean)p2;
+                break;
+            case "doubleClick":
+                generalSettings.doubleClick = (boolean)p2;
                 break;
             case "showIndicator":
                 generalSettings.showIndicator = (boolean)p2;

--- a/launcher/src/main/java/com/benny/openlauncher/util/LauncherAction.java
+++ b/launcher/src/main/java/com/benny/openlauncher/util/LauncherAction.java
@@ -41,13 +41,15 @@ public class LauncherAction {
     public static void RunAction(Action act,final Context c,final Activity a){
         switch (act){
             case LockScreen:
-                try{
-                    ((DevicePolicyManager)c.getSystemService(Context.DEVICE_POLICY_SERVICE)).lockNow();
-                }catch (Exception e){
-                    Tool.toast(c,c.getString(R.string.toast_plzenabledeviceadmin));
-                    Intent intent = new Intent();
-                    intent.setComponent(new ComponentName("com.android.settings","com.android.settings.DeviceAdminSettings"));
-                    c.startActivity(intent);
+                if(LauncherSettings.getInstance(c).generalSettings.doubleClick) {
+                    try{
+                        ((DevicePolicyManager)c.getSystemService(Context.DEVICE_POLICY_SERVICE)).lockNow();
+                    }catch (Exception e){
+                        Tool.toast(c,c.getString(R.string.toast_plzenabledeviceadmin));
+                        Intent intent = new Intent();
+                        intent.setComponent(new ComponentName("com.android.settings","com.android.settings.DeviceAdminSettings"));
+                        c.startActivity(intent);
+                    }
                 }
                 break;
             case ClearRam:

--- a/launcher/src/main/java/com/benny/openlauncher/util/LauncherSettings.java
+++ b/launcher/src/main/java/com/benny/openlauncher/util/LauncherSettings.java
@@ -222,6 +222,7 @@ public class LauncherSettings {
         public boolean fullscreen = false;
         public boolean swipe = false;
         public boolean clickToOpen = false;
+        public boolean doubleClick = false;
         public boolean showIndicator = true;
         public boolean hideIcon = false;
 

--- a/launcher/src/main/res/values/strings.xml
+++ b/launcher/src/main/res/values/strings.xml
@@ -97,10 +97,11 @@
 
     <string name="settings_group_desktop">Desktop</string>
     <string name="settings_group_dock">Dock</string>
-    <string name="settings_group_drawer">App drawer</string>
+    <string name="settings_group_drawer">App Drawer</string>
+    <string name="settings_group_input">Input</string>
     <string name="settings_group_color">Colors</string>
     <string name="settings_group_icons">Icons</string>
-    <string name="settings_group_others">Others</string>
+    <string name="settings_group_other">Other</string>
 
     <string name="settings_desktopStyle">Style</string>
     <string name="settings_desktopStyle_summary">Choose between different styles for your desktop.</string>
@@ -110,10 +111,6 @@
     <string name="settings_desktopSize_summary">Set the desktop grid size.</string>
     <string name="settings_desktopFull">Fullscreen</string>
     <string name="settings_desktopFull_summary">Enable fullscreen for your desktop.</string>
-    <string name="settings_desktopSwipe">Fast swipe Drawer</string>
-    <string name="settings_desktopSwipe_summary">Swipe on your desktop to open the app drawer.</string>
-    <string name="settings_desktopClick">Fast click Drawer</string>
-    <string name="settings_desktopClick_summary">Click on your desktop to open the app drawer.</string>
     <string name="settings_desktopIndicator">Desktop indicator</string>
     <string name="settings_desktopIndicator_summary">Show the page indicator on the desktop.</string>
 
@@ -132,6 +129,13 @@
     <string name="settings_drawerSize_summary">Set the drawer grid size.</string>
     <string name="settings_drawerPage">Remember last page</string>
     <string name="settings_drawerPage_summary">The app drawer will save the last opened page.</string>
+
+    <string name="settings_desktopSwipe">Fast swipe Drawer</string>
+    <string name="settings_desktopSwipe_summary">Swipe up on the drawer app icon to open the app drawer.</string>
+    <string name="settings_desktopClick">Fast click Drawer</string>
+    <string name="settings_desktopClick_summary">Tap your desktop to open the app drawer.</string>
+    <string name="settings_doubleClick">Double click to lock screen</string>
+    <string name="settings_doubleClick_summary">Double tap your desktop to lock the device.</string>
 
     <string name="settings_colorDock">Dock</string>
     <string name="settings_colorDock_summary">Dock background color.</string>


### PR DESCRIPTION
This pull request has a few changes:

- add the option to disable the double click action on the desktop
- move some of the settings around so that the boolean settings are grouped together
- a few changes to the strings
- move the input related settings to their own category