### PR TITLE
Gesture controls on the desktop

### DIFF
--- a/launcher/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/launcher/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -549,7 +549,8 @@ public class Home extends Activity implements DrawerLayout.DrawerListener {
         final ArrayList<String> minBarArrangement = LauncherSettings.getInstance(this).generalSettings.miniBarArrangement;
         if (minBarArrangement == null) {
             LauncherSettings.getInstance(this).generalSettings.miniBarArrangement = new ArrayList<>();
-            for (LauncherAction.ActionItem item : LauncherAction.actionItems) {
+            for (int i = 0; i < 6; i++) {
+                LauncherAction.ActionItem item = LauncherAction.actionItems[i];
                 LauncherSettings.getInstance(this).generalSettings.miniBarArrangement.add("0" + item.label.toString());
                 labels.add(item.label.toString());
                 icons.add(item.icon);

--- a/launcher/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/launcher/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -779,6 +779,9 @@ public class Home extends Activity implements DrawerLayout.DrawerListener {
     /**
      * Call this to open the app drawer with animation
      */
+    public void openAppDrawer() {
+        openAppDrawer(desktop,-1,-1);
+    }
     public void openAppDrawer(View view) {
         openAppDrawer(view,-1,-1);
     }

--- a/launcher/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/launcher/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -541,15 +541,12 @@ public class Home extends Activity implements DrawerLayout.DrawerListener {
 
     public void initMinBar() {
         final ArrayList<String> labels = new ArrayList<>();
-        labels.add(getString(R.string.edit));
-
-        ArrayList<Integer> icons = new ArrayList<>();
-        icons.add(R.drawable.ic_mode_edit_black_24dp);
-
+        final ArrayList<Integer> icons = new ArrayList<>();
         final ArrayList<String> minBarArrangement = LauncherSettings.getInstance(this).generalSettings.miniBarArrangement;
+
         if (minBarArrangement == null) {
             LauncherSettings.getInstance(this).generalSettings.miniBarArrangement = new ArrayList<>();
-            for (int i = 0; i < 6; i++) {
+            for (int i = 0; i < 7; i++) {
                 LauncherAction.ActionItem item = LauncherAction.actionItems[i];
                 LauncherSettings.getInstance(this).generalSettings.miniBarArrangement.add("0" + item.label.toString());
                 labels.add(item.label.toString());
@@ -585,21 +582,17 @@ public class Home extends Activity implements DrawerLayout.DrawerListener {
         minBar.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-                if (i == 0)
-                    startActivityForResult(new Intent(Home.this, MiniBarEditActivity.class), MINIBAR_EDIT);
-                else {
-                    LauncherAction.Action action = LauncherAction.Action.valueOf(labels.get(i));
-                    LauncherAction.RunAction(action, Home.this);
-                    if (action == LauncherAction.Action.LauncherSettings || action == LauncherAction.Action.DeviceSettings) {
-                        (new Handler()).postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                drawerLayout.closeDrawers();
-                            }
-                        }, 500);
-                    } else {
-                        drawerLayout.closeDrawers();
-                    }
+                LauncherAction.Action action = LauncherAction.Action.valueOf(labels.get(i));
+                LauncherAction.RunAction(action, Home.this);
+                if (action == LauncherAction.Action.LauncherSettings || action == LauncherAction.Action.DeviceSettings) {
+                    (new Handler()).postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            drawerLayout.closeDrawers();
+                        }
+                    }, 500);
+                } else {
+                    drawerLayout.closeDrawers();
                 }
             }
         });
@@ -719,8 +712,6 @@ public class Home extends Activity implements DrawerLayout.DrawerListener {
                 configureWidget(data);
             } else if (requestCode == REQUEST_CREATE_APPWIDGET) {
                 createWidget(data);
-            } else if (requestCode == MINIBAR_EDIT) {
-                initMinBar();
             }
         } else if (resultCode == RESULT_CANCELED && data != null) {
             int appWidgetId =

--- a/launcher/src/main/java/com/benny/openlauncher/activity/SettingsActivity.java
+++ b/launcher/src/main/java/com/benny/openlauncher/activity/SettingsActivity.java
@@ -83,8 +83,8 @@ public class SettingsActivity extends BaseSettingsActivity implements MaterialPr
 
                     .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_input)))
                     .add(new MaterialPrefFragment.TBPref("swipe", (getString(R.string.settings_desktopSwipe)), (getString(R.string.settings_desktopSwipe_summary)), generalSettings.swipe))
-                    .add(new MaterialPrefFragment.TBPref("clickToOpen", (getString(R.string.settings_desktopClick)), (getString(R.string.settings_desktopClick_summary)), generalSettings.clickToOpen))
-                    .add(new MaterialPrefFragment.TBPref("doubleClick", (getString(R.string.settings_doubleClick)), (getString(R.string.settings_doubleClick_summary)), generalSettings.doubleClick))
+                    .add(new MaterialPrefFragment.ButtonPref("singleClick", (getString(R.string.settings_singleClick)), (getString(R.string.settings_singleClick_summary))))
+                    .add(new MaterialPrefFragment.ButtonPref("doubleClick", (getString(R.string.settings_doubleClick)), (getString(R.string.settings_doubleClick_summary))))
 
                     .add(new MaterialPrefFragment.GroupTitle(getString(R.string.settings_group_color)))
                     .add(new MaterialPrefFragment.ColorPref("dockBackground",(getString(R.string.settings_colorDock)),(getString(R.string.settings_colorDock_summary)),generalSettings.dockColor))
@@ -150,11 +150,11 @@ public class SettingsActivity extends BaseSettingsActivity implements MaterialPr
             case "swipe":
                 generalSettings.swipe = (boolean)value;
                 break;
-            case "clickToOpen":
-                generalSettings.clickToOpen = (boolean)value;
+            case "singleClick":
+                generalSettings.singleClick = (int)value;
                 break;
             case "doubleClick":
-                generalSettings.doubleClick = (boolean)value;
+                generalSettings.doubleClick = (int)value;
                 break;
             case "showIndicator":
                 generalSettings.showIndicator = (boolean)value;
@@ -273,6 +273,14 @@ public class SettingsActivity extends BaseSettingsActivity implements MaterialPr
                 break;
             case "desktopMode":
                 Desktop.startStylePicker(this);
+                prepareRestart();
+                break;
+            case "singleClick":
+                Desktop.startSingleClickPicker(this);
+                prepareRestart();
+                break;
+            case "doubleClick":
+                Desktop.startDoubleClickPicker(this);
                 prepareRestart();
                 break;
             case "iconHide":

--- a/launcher/src/main/java/com/benny/openlauncher/util/LauncherAction.java
+++ b/launcher/src/main/java/com/benny/openlauncher/util/LauncherAction.java
@@ -16,6 +16,7 @@ import android.view.View;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.benny.openlauncher.R;
 import com.benny.openlauncher.activity.Home;
+import com.benny.openlauncher.activity.MiniBarEditActivity;
 import com.benny.openlauncher.activity.SettingsActivity;
 
 import net.qiujuer.genius.blur.StackBlur;
@@ -23,6 +24,7 @@ import net.qiujuer.genius.blur.StackBlur;
 import java.io.IOException;
 import java.util.List;
 
+import static com.benny.openlauncher.activity.Home.launcher;
 import static com.benny.openlauncher.activity.Home.resources;
 
 public class LauncherAction {
@@ -30,6 +32,7 @@ public class LauncherAction {
     private static boolean clearingRam = false;
 
     public static ActionItem[] actionItems = new ActionItem[]{
+            new ActionItem(Action.EditMinBar, resources.getString(R.string.edit), R.drawable.ic_mode_edit_black_24dp),
             new ActionItem(Action.SetWallpaper, resources.getString(R.string.minibar_1), R.drawable.ic_photo_black_24dp),
             new ActionItem(Action.LockScreen, resources.getString(R.string.minibar_2), R.drawable.ic_lock_black_24dp),
             new ActionItem(Action.ClearRam, resources.getString(R.string.minibar_3), R.drawable.ic_donut_large_black_24dp),
@@ -42,6 +45,11 @@ public class LauncherAction {
 
     public static void RunAction(Action act, final Context c) {
         switch (act) {
+            case EditMinBar:
+                Intent minbar = new Intent(c, MiniBarEditActivity.class);
+                c.startActivity(minbar);
+                launcher.initMinBar();
+                break;
             case LockScreen:
                 try {
                     ((DevicePolicyManager) c.getSystemService(Context.DEVICE_POLICY_SERVICE)).lockNow();
@@ -170,6 +178,6 @@ public class LauncherAction {
     }
 
     public enum Action {
-        LockScreen, ClearRam, SetWallpaper, DeviceSettings, LauncherSettings, ThemePicker, VolumeDialog, OpenAppDrawer
+        EditMinBar, LockScreen, ClearRam, SetWallpaper, DeviceSettings, LauncherSettings, ThemePicker, VolumeDialog, OpenAppDrawer
     }
 }

--- a/launcher/src/main/java/com/benny/openlauncher/util/LauncherAction.java
+++ b/launcher/src/main/java/com/benny/openlauncher/util/LauncherAction.java
@@ -15,6 +15,7 @@ import android.view.View;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.benny.openlauncher.R;
+import com.benny.openlauncher.activity.Home;
 import com.benny.openlauncher.activity.SettingsActivity;
 
 import net.qiujuer.genius.blur.StackBlur;
@@ -35,7 +36,8 @@ public class LauncherAction {
             new ActionItem(Action.DeviceSettings, resources.getString(R.string.minibar_4), R.drawable.ic_settings_applications_black_24dp),
             new ActionItem(Action.LauncherSettings, resources.getString(R.string.minibar_5), R.drawable.ic_settings_black_24dp),
             //new ActionItem(Action.ThemePicker,resources.getString(R.string.minibar_6),R.drawable.ic_brush_black_24dp),
-            new ActionItem(Action.VolumeDialog, resources.getString(R.string.minibar_7), R.drawable.ic_volume_up_black_24dp)
+            new ActionItem(Action.VolumeDialog, resources.getString(R.string.minibar_7), R.drawable.ic_volume_up_black_24dp),
+            new ActionItem(Action.OpenAppDrawer, resources.getString(R.string.minibar_7), R.drawable.ic_volume_up_black_24dp)
     };
 
     public static void RunAction(Action act, final Context c) {
@@ -126,6 +128,9 @@ public class LauncherAction {
             case LauncherSettings:
                 c.startActivity(new Intent(c, SettingsActivity.class));
                 break;
+            case OpenAppDrawer:
+                Home.launcher.openAppDrawer();
+                break;
         }
     }
 
@@ -165,6 +170,6 @@ public class LauncherAction {
     }
 
     public enum Action {
-        LockScreen, ClearRam, SetWallpaper, DeviceSettings, LauncherSettings, ThemePicker, VolumeDialog
+        LockScreen, ClearRam, SetWallpaper, DeviceSettings, LauncherSettings, ThemePicker, VolumeDialog, OpenAppDrawer
     }
 }

--- a/launcher/src/main/java/com/benny/openlauncher/util/LauncherSettings.java
+++ b/launcher/src/main/java/com/benny/openlauncher/util/LauncherSettings.java
@@ -129,6 +129,14 @@ public class LauncherSettings {
         readDesktopData(gson, generalSettings.desktopMode);
     }
 
+    public void setSingleClickGesture(int value) {
+        generalSettings.singleClick = value;
+    }
+
+    public void setDoubleClickGesture(int value) {
+        generalSettings.doubleClick = value;
+    }
+
     public void switchDesktopMode(Desktop.DesktopMode mode) {
         writeSettings();
 
@@ -222,8 +230,8 @@ public class LauncherSettings {
         public boolean desktopSearchBar = true;
         public boolean fullscreen = false;
         public boolean swipe = false;
-        public boolean clickToOpen = false;
-        public boolean doubleClick = false;
+        public int singleClick = 0;
+        public int doubleClick = 0;
         public boolean showIndicator = true;
         public boolean desktopShowLabel = true;
         public boolean hideIcon = false;

--- a/launcher/src/main/java/com/benny/openlauncher/widget/Desktop.java
+++ b/launcher/src/main/java/com/benny/openlauncher/widget/Desktop.java
@@ -414,22 +414,28 @@ public class Desktop extends SmoothViewPager implements OnDragListener, DesktopC
                         case 0:
                             break;
                         case 1:
-                            LauncherAction.RunAction(LauncherAction.Action.SetWallpaper, desktop.getContext());
+                            LauncherAction.RunAction(LauncherAction.Action.EditMinBar, desktop.getContext());
                             break;
                         case 2:
-                            LauncherAction.RunAction(LauncherAction.Action.LockScreen, desktop.getContext());
+                            LauncherAction.RunAction(LauncherAction.Action.SetWallpaper, desktop.getContext());
                             break;
                         case 3:
-                            LauncherAction.RunAction(LauncherAction.Action.ClearRam, desktop.getContext());
+                            LauncherAction.RunAction(LauncherAction.Action.LockScreen, desktop.getContext());
                             break;
                         case 4:
-                            LauncherAction.RunAction(LauncherAction.Action.DeviceSettings, desktop.getContext());
+                            LauncherAction.RunAction(LauncherAction.Action.ClearRam, desktop.getContext());
                             break;
                         case 5:
-                            LauncherAction.RunAction(LauncherAction.Action.LauncherSettings, desktop.getContext());
+                            LauncherAction.RunAction(LauncherAction.Action.DeviceSettings, desktop.getContext());
                             break;
                         case 6:
+                            LauncherAction.RunAction(LauncherAction.Action.LauncherSettings, desktop.getContext());
+                            break;
+                        case 7:
                             LauncherAction.RunAction(LauncherAction.Action.VolumeDialog, desktop.getContext());
+                            break;
+                        case 8:
+                            LauncherAction.RunAction(LauncherAction.Action.OpenAppDrawer, desktop.getContext());
                             break;
                         default:
                             break;
@@ -642,6 +648,7 @@ public class Desktop extends SmoothViewPager implements OnDragListener, DesktopC
         MaterialDialog.Builder builder = new MaterialDialog.Builder(context);
         builder.title(context.getString(R.string.settings_single_click_title))
             .items(context.getString(R.string.settings_gesture_none),
+                context.getString(R.string.settings_gesture_zero),
                 context.getString(R.string.settings_gesture_one),
                 context.getString(R.string.settings_gesture_two),
                 context.getString(R.string.settings_gesture_three),

--- a/launcher/src/main/java/com/benny/openlauncher/widget/Desktop.java
+++ b/launcher/src/main/java/com/benny/openlauncher/widget/Desktop.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Point;
+import android.os.Handler;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.AttributeSet;
@@ -409,8 +410,30 @@ public class Desktop extends SmoothViewPager implements OnDragListener, DesktopC
 
                 @Override
                 public boolean onDoubleTap(int i) {
-                    if (LauncherSettings.getInstance(getContext()).generalSettings.doubleClick)
-                        LauncherAction.RunAction(LauncherAction.Action.LockScreen, desktop.getContext());
+                    switch (LauncherSettings.getInstance(getContext()).generalSettings.doubleClick) {
+                        case 0:
+                            break;
+                        case 1:
+                            LauncherAction.RunAction(LauncherAction.Action.SetWallpaper, desktop.getContext());
+                            break;
+                        case 2:
+                            LauncherAction.RunAction(LauncherAction.Action.LockScreen, desktop.getContext());
+                            break;
+                        case 3:
+                            LauncherAction.RunAction(LauncherAction.Action.ClearRam, desktop.getContext());
+                            break;
+                        case 4:
+                            LauncherAction.RunAction(LauncherAction.Action.DeviceSettings, desktop.getContext());
+                            break;
+                        case 5:
+                            LauncherAction.RunAction(LauncherAction.Action.LauncherSettings, desktop.getContext());
+                            break;
+                        case 6:
+                            LauncherAction.RunAction(LauncherAction.Action.VolumeDialog, desktop.getContext());
+                            break;
+                        default:
+                            break;
+                    }
                     return true;
                 }
             };
@@ -471,8 +494,14 @@ public class Desktop extends SmoothViewPager implements OnDragListener, DesktopC
             layout.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    if (!desktop.inEditMode && LauncherSettings.getInstance(getContext()).generalSettings.clickToOpen) {
-                        Home.launcher.openAppDrawer(desktop, (int) currentEvent.getX(), (int) currentEvent.getY());
+                    if (!desktop.inEditMode) {
+                        switch (LauncherSettings.getInstance(getContext()).generalSettings.singleClick) {
+                            case 0:
+                                break;
+                            case 1:
+                                LauncherAction.RunAction(LauncherAction.Action.OpenAppDrawer, desktop.getContext());
+                                break;
+                        }
                     }
 
                     scaleFactor = 1f;
@@ -586,6 +615,45 @@ public class Desktop extends SmoothViewPager implements OnDragListener, DesktopC
                         LauncherSettings.getInstance(context).switchDesktopMode(DesktopMode.values()[position]);
                     }
                 }).show();
+    }
+
+    public static void startSingleClickPicker(final Context context) {
+        final String[] items = new String[LauncherAction.actionItems.length];
+        for (int i = 0; i < LauncherAction.actionItems.length; i++) {
+            items[i] = LauncherAction.actionItems[i].toString();
+        }
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(context);
+        builder.title(context.getString(R.string.settings_double_click_title))
+            .items(context.getString(R.string.settings_gesture_none),
+                context.getString(R.string.settings_gesture_seven))
+            .itemsCallback(new MaterialDialog.ListCallback() {
+                @Override
+                public void onSelection(MaterialDialog dialog, View itemView, int position, CharSequence text) {
+                    LauncherSettings.getInstance(context).setDoubleClickGesture(position);
+                }
+            }).show();
+    }
+
+    public static void startDoubleClickPicker(final Context context) {
+        final String[] items = new String[LauncherAction.actionItems.length];
+        for (int i = 0; i < LauncherAction.actionItems.length; i++) {
+            items[i] = LauncherAction.actionItems[i].toString();
+        }
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(context);
+        builder.title(context.getString(R.string.settings_single_click_title))
+            .items(context.getString(R.string.settings_gesture_none),
+                context.getString(R.string.settings_gesture_one),
+                context.getString(R.string.settings_gesture_two),
+                context.getString(R.string.settings_gesture_three),
+                context.getString(R.string.settings_gesture_four),
+                context.getString(R.string.settings_gesture_five),
+                context.getString(R.string.settings_gesture_six))
+            .itemsCallback(new MaterialDialog.ListCallback() {
+                @Override
+                public void onSelection(MaterialDialog dialog, View itemView, int position, CharSequence text) {
+                    LauncherSettings.getInstance(context).setSingleClickGesture(position);
+                }
+            }).show();
     }
 
     public static class Item implements Parcelable {

--- a/launcher/src/main/res/values/strings.xml
+++ b/launcher/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="settings_single_click_title">Single click action</string>
     <string name="settings_double_click_title">Double click action</string>
     <string name="settings_gesture_none">None</string>
+    <string name="settings_gesture_zero">Minbar Settings</string>
     <string name="settings_gesture_one">Set wallpaper</string>
     <string name="settings_gesture_two">Lock screen</string>
     <string name="settings_gesture_three">Clear RAM</string>
@@ -185,6 +186,6 @@
     <string name="request_please_wait2">Searching for installed apps. Please wait.</string>
     <string name="request_toast">No apps selected. Show all apps in drawer?</string>
     <string name="settings_group_others">Others</string>
-    <string name="edit">Edit</string>
+    <string name="edit">EditMinBar</string>
 
 </resources>

--- a/launcher/src/main/res/values/strings.xml
+++ b/launcher/src/main/res/values/strings.xml
@@ -94,6 +94,16 @@
     <string name="settings_stylePicker_vertical">Vertical</string>
     <string name="settings_stylePicker_normal">Normal</string>
     <string name="settings_stylePicker_allApps">Show all apps (Experimental)</string>
+    <string name="settings_single_click_title">Single click action</string>
+    <string name="settings_double_click_title">Double click action</string>
+    <string name="settings_gesture_none">None</string>
+    <string name="settings_gesture_one">Set wallpaper</string>
+    <string name="settings_gesture_two">Lock screen</string>
+    <string name="settings_gesture_three">Clear RAM</string>
+    <string name="settings_gesture_four">Device settings</string>
+    <string name="settings_gesture_five">Launcher Settings</string>
+    <string name="settings_gesture_six">Volume Dialog</string>
+    <string name="settings_gesture_seven">Open app drawer</string>
 
     <string name="settings_group_desktop">Desktop</string>
     <string name="settings_group_dock">Dock</string>
@@ -137,10 +147,10 @@
 
     <string name="settings_desktopSwipe">Fast swipe drawer</string>
     <string name="settings_desktopSwipe_summary">Swipe up on the drawer app icon to open the app drawer.</string>
-    <string name="settings_desktopClick">Fast click drawer</string>
-    <string name="settings_desktopClick_summary">Tap your desktop to open the app drawer.</string>
-    <string name="settings_doubleClick">Double click to lock screen</string>
-    <string name="settings_doubleClick_summary">Double tap your desktop to lock the device.</string>
+    <string name="settings_singleClick">Single click</string>
+    <string name="settings_singleClick_summary">Single click action.</string>
+    <string name="settings_doubleClick">Double click</string>
+    <string name="settings_doubleClick_summary">Double click action.</string>
 
     <string name="settings_colorDock">Dock</string>
     <string name="settings_colorDock_summary">Dock background color.</string>


### PR DESCRIPTION
I know this code is not ready for a merge yet, it is just an initial workup for gesture controls on the desktop, but I wanted your input on the changes I have made so far.

Currently there are a few issues.
- [ ] single click is implemented in a separate location and conflicts with the double click gesture
- [ ] other gestures (swipe down, swipe up, swipe left, swipe right, pinch, and unpinch) are not added yet
- [ ] minbar adds every LauncherAction instead of a select few as default
- [ ] no icon for OpenAppDrawer

The only other action I have added right now is opening the app drawer, but it would be easy to add more in the future. I am still unsure of how to move the single click listener to the same location as the other listeners, which would be ideal. I can add the other gestures after I figure out these issues.

The main action I want to add to LauncherActions an action to open a specific app. Maybe the HideApps fragment could be modified to either select a single app or a multitude of apps. Then the fragment could also get called by a launcher action to select an app to open for a specific gesture. I am still thinking about the best way to implement this.